### PR TITLE
Support NF cards' power control and status checking via Redfish 

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -1754,15 +1754,10 @@ inline void bhNameMatch(std::string& systemId_path, int& match)
 			match = 0;
 }
 
-inline void nfStatusParse(std::variant<std::string>& property, std::string& status)
+inline void nfStatusParse(std::string& property, std::string& status)
 {
-	const std::string* value = 
-		std::get_if<std::string>(&property);
-
-	std::string nf_attached;
-	nf_attached.assign(*value);
-	size_t pos = nf_attached.find(".");
-	status.assign(nf_attached.substr(pos + 1, nf_attached.length()));
+	size_t pos = property.find(".");
+	status.assign(property.substr(pos + 1, property.length()));
 }
 
 /**
@@ -1977,8 +1972,13 @@ class SystemActionsReset : public Node
 								
 								else 
 								{
-								    std::string status;
-									  nfStatusParse(property, status);
+								    std::string nf_attached, status;
+										const std::string* value = 
+										    std::get_if<std::string>(&property);
+												
+										nf_attached.assign(*value);
+									  nfStatusParse(nf_attached, status);
+
 									  if(status == "false")
 										{
 										    messages::internalError(asyncResp->res);
@@ -2093,9 +2093,12 @@ class Systems : public Node
 							  const std::variant<std::string>& property) {
 
 							if((!ec) && match) {
-							  std::string status;
-
-								nfStatusParse(property, status);
+								std::string nf_attached, status;
+								const std::string* value = 
+										std::get_if<std::string>(&property);
+												
+								nf_attached.assign(*value);
+								nfStatusParse(nf_attached, status);
 
 								if(status == "true")
 								{
@@ -2326,9 +2329,12 @@ class SystemResetActionInfo : public Node
 							  const std::variant<std::string>& property) {
 
 							if((!ec) && match) {
-							  std::string status;
-
-								nfStatusParse(property, status);
+								std::string nf_attached, status;
+								const std::string* value = 
+										std::get_if<std::string>(&property);
+												
+								nf_attached.assign(*value);
+								nfStatusParse(nf_attached, status);
 
 								if(status == "true")
 								{


### PR DESCRIPTION
1. When GET system information via SystemCollection, only attached NF cards are listed.

2. In Redfish System GET operations, only information of attached NF cards would be returned. Queries to other unattached systems would be denied via an error message.
The same process is introduced in ResetInformation GET of a NF card as well.

3. Checking power state of an available NF card in GET.

4. POST operation in SystemRest is only allowed for the attached NF cards.
